### PR TITLE
Change link for Mitgliedsantrag

### DIFF
--- a/source/verein/index.md
+++ b/source/verein/index.md
@@ -23,7 +23,7 @@ Hier findet ihr die wichtigsten Dokumente:
 
 * [Satzung](../dateien/Satzung_Westwoodlabs.pdf)
 * [Beitragsordnung](https://wiki.westwoodlabs.de/Beitragsordnung)
-* [Mitgliedsantrag](../dateien/Mitgliedsantrag.pdf)
+* [Mitgliedsantrag](https://github.com/Westwoodlabs/Mitgliedsantrag/releases/download/master/Mitgliedsantrag_Westwoodlabs.pdf)
  
 
 ## Spenden


### PR DESCRIPTION
The link to the Mitgliedsantrag now points directly to the latest version from the corresponding GitHub repo (Westwoodlabs/Membership application)